### PR TITLE
Add Docker to SJSU-DEV2

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04 as build_stage
+
+WORKDIR /SJSU-DEV2
+
+RUN apt-get update \
+  && apt-get install -y curl cmake git make g++ python3 \
+  && apt-get install sudo -y
+
+COPY . .
+
+RUN ls -la
+
+RUN ls tools
+
+RUN ["./setup"]

--- a/setup
+++ b/setup
@@ -53,7 +53,7 @@ function print_status_nl() {
 
 # Make sure only non-root users can run our script
 function quit_if_script_was_run_as_root() {
-  if [[ $EUID -eq 0 ]]; then
+  if  [[ ! -f /.dockerenv && $EUID -eq 0 ]]; then
     echo "SJSU-DEV installer script must NOT be run as root! " 1>&2
     exit 1
   fi


### PR DESCRIPTION
### How to test this
1. ensure Docker is installed on your machine
> to avoid using `sudo` before every Docker command, you can follow the [docker docs guide](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)
2. from the `SJSU-DEV2` project folder, run `docker build -t sj-dev2 -f docker/Dockerfile.base .`
> `-t` specifies the image name, `-f` specifies the location of the Dockerfile to build from, the `.` at the end represents the build context.
3. After some time, the image should be created with the `setup` script already have been ran.
> Ensure this is true by running `docker images` and seeing the following:
```
REPOSITORY                               TAG                 IMAGE ID            CREATED            SIZE
sj-dev2                                latest              4c496b6a2a39        15 minutes ago      5.16GB
```
4. With the [Remote Containers VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed, navigate to the dedicated tab on your VS Code window:
![image](https://user-images.githubusercontent.com/36345325/105146225-96781f80-5ab4-11eb-9d3d-e6fb60edcb52.png)

5. Right click the container and select `Attach in new Window`. A new VS Code window should open shortly.
6. In the new window click the `Open Folder` button and enter `/SJSU-DEV2` in the top middle input:
![image](https://user-images.githubusercontent.com/36345325/105146464-e2c35f80-5ab4-11eb-8346-bf4558fbd45f.png)
7. The new window should now open the project with a dedicated terminal.
![image](https://user-images.githubusercontent.com/36345325/105146680-1c946600-5ab5-11eb-89a5-a54f845f5f14.png)
8. Run `make application` on hello world to ensure no errors:
![image](https://user-images.githubusercontent.com/36345325/105146791-39309e00-5ab5-11eb-9458-1cab17bd93ea.png)


### Issues to address before PR is ready for review
- [ ] Mapping serial ports to docker container (possible help: [windows docs](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/hardware-devices-in-containers#what-devices-are-supported), [obscure blog post](https://sandervandevelde.wordpress.com/2020/05/18/access-com-ports-with-docker-containers-on-windows/))
- [ ] flashing a device from the container
- [ ] add setup script to prompt windows users to install docker
- [ ] potentially add helper command to spin up the container, so students dont have to enter complicated docker command
- [ ] reduce size of docker image, potentially with multistage builds (e.g. first container is 5.16GB, which then creates a secondary container that is somehow smaller for development)
- [ ] allow color escape codes to work in docker terminal