### PR TITLE
Add IsConnected implementation to ESP8266

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -109,6 +109,7 @@
         "CWJAP",
         "CWLIF",
         "CWQAP",
+        "CWSTATE",
         "CWSAP",
         "CWSIZER",
         "CWSTRTR",

--- a/demos/multiplatform/esp8266/project_config.hpp
+++ b/demos/multiplatform/esp8266/project_config.hpp
@@ -3,6 +3,6 @@
 // options you can change.
 #pragma once
 
-#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_INFO
+#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_DEBUG
 
 #include "config.hpp"

--- a/library/peripherals/lpc40xx/uart.hpp
+++ b/library/peripherals/lpc40xx/uart.hpp
@@ -552,10 +552,10 @@ class UartBase : public sjsu::Uart
 
 /// Uart Driver for the lpc40xx platform.
 ///
-/// @tparam - defaults to 1024 bytes for the queue size. You can configure this
+/// @tparam - defaults to 2048 bytes for the queue size. You can configure this
 ///           for a higher or lower number of bytes. Note: that the larger this
 ///           value, the larger this object's size is.
-template <size_t queue_size = 1024>
+template <size_t queue_size = 2048>
 class Uart : public sjsu::lpc40xx::UartBase
 {
  public:
@@ -572,7 +572,7 @@ class Uart : public sjsu::lpc40xx::UartBase
   std::array<uint8_t, queue_size> queue_;
 };
 
-template <int port, size_t queue_size = 1024>
+template <int port, size_t queue_size = 2048>
 inline Uart<queue_size> & GetUart()
 {
   if constexpr (port == 0)

--- a/library/peripherals/uart.hpp
+++ b/library/peripherals/uart.hpp
@@ -5,8 +5,8 @@
 #include <limits>
 #include <span>
 
-#include "peripherals/inactive.hpp"
 #include "module.hpp"
+#include "peripherals/inactive.hpp"
 #include "utility/error_handling.hpp"
 #include "utility/time/time.hpp"
 
@@ -180,15 +180,19 @@ class Uart : public Module<UartSettings_t>
   size_t Read(std::span<uint8_t> data, std::chrono::nanoseconds timeout)
   {
     size_t position = 0;
+    // Read as much data out of the Uart port initially before waiting
+    position += Read(data.subspan(position));
 
-    Wait(timeout, [this, data, &position]() -> bool {
-      position += Read(data.subspan(position));
-      if (position >= data.size())
-      {
-        return true;
-      }
-      return false;
-    });
+    Wait(timeout,
+         [this, data, &position]() -> bool
+         {
+           position += Read(data.subspan(position));
+           if (position >= data.size())
+           {
+             return true;
+           }
+           return false;
+         });
 
     return position;
   }

--- a/library/platforms/targets/lpc40xx/startup.cpp
+++ b/library/platforms/targets/lpc40xx/startup.cpp
@@ -19,9 +19,6 @@
 #include "utility/macros.hpp"
 #include "utility/time/time.hpp"
 
-// Uart port 0 is used to communicate back to the host computer
-auto & uart0 = sjsu::lpc40xx::GetUart<0, 1024>();
-
 // Private namespace to make sure that these do not conflict with other globals
 namespace
 {
@@ -33,6 +30,9 @@ sjsu::lpc40xx::SystemController system_controller(clock_configuration);
 
 // Create timer0 to be used by lower level initialization for uptime calculation
 sjsu::cortex::DwtCounter arm_dwt_counter;
+
+// Uart port 0 is used to communicate back to the host computer
+auto & uart0 = sjsu::lpc40xx::GetUart<0>();
 
 // System timer is used to count milliseconds of time and to run the RTOS
 // scheduler.


### PR DESCRIPTION
- This implemenation does not work on older firmware esp8266
- Add ReadRaw() to esp8266 to allow for a non-blocking method of reading
  data from the serial port directly.
- Modify example project to use ReadRaw after 1 second delay
- Make UART0 buffer 2kB
- Make esp8266 uart buffer 2kB
- Make lpc40xx uart default to 2kB